### PR TITLE
Make GitHub not detect *.f as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.f linguist-language=Text


### PR DESCRIPTION
Hello/hej!

Please merge this, if you'd like GitHub not to detect your `.f` files as Forth.

Thanks!
